### PR TITLE
Fix API container build

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,12 +1,13 @@
 FROM php:7.3-apache
 
 RUN apt-get update && apt-get install -y \
-        mysql-client \
-        libpng-dev
+        default-mysql-client \
+        libpng-dev \
+        libicu-dev
 
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/src/public
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 RUN a2enmod rewrite
 
-RUN docker-php-ext-install json mbstring pdo pdo_mysql gd
+RUN docker-php-ext-install json mbstring pdo pdo_mysql gd intl


### PR DESCRIPTION
- Changed `mysql-client` to `default-mysql-client` because the former did not resolve to an installable package
- Added the `intl` extension since it is required for the API and not installed by default
- Added the `libicu-dev` package because that is needed to install the `intl` extension