### PR TITLE
Point Apache root for API to new location of the public directory

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
         libpng-dev \
         libicu-dev
 
-ENV APACHE_DOCUMENT_ROOT=/var/www/html/src/public
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 RUN a2enmod rewrite


### PR DESCRIPTION
Recently, the API's `public` directory was moved out of `src` and into the root of the repo. This change makes it so that the docker build knows where it moved.